### PR TITLE
Equivalent city and camera rotation pages behavior

### DIFF
--- a/web/viewer_with_2panes_rot_cam.html
+++ b/web/viewer_with_2panes_rot_cam.html
@@ -387,6 +387,15 @@ class MapView{
     // #endregion
 }
 
+const MJS_TRANSFORM = new THREE.Matrix4()
+        .makeRotationFromEuler(
+            new THREE.Euler(-Math.PI / 2, 0, 0));
+
+// OR 
+// const MJS_TRANSFORM = new THREE.Matrix4()
+//         .makeRotationFromEuler(
+//             new THREE.Euler(Math.PI / 2, 0, 0))
+//         .invert();
 
 // Render City in Mapillary
 class CityRenderer {
@@ -452,16 +461,19 @@ class CityRenderer {
             reference.lat,
             reference.alt
         );
-        mesh.position.set( e, n, u );
+        const position = new THREE.Vector3(e, n, u)
+            .applyMatrix4(MJS_TRANSFORM);
+
+        mesh.position.copy(position);
 
         // The initial position set with geodeticToEnu is based on Mapillary's orientation, Since
         // the camera is being reoriented into the standard webgl orientation, the position needs
         // to be transformed to work correctly
-        const qOrient = quatFromAxis( [0,1,0], [0,0,1], [1,0,0] ).invert(); // FWD: +X, UP: +Z, RIGHT: +Y
-        const qAlign  = quatFromAxis( [0,0,-1], [0,1,0], [1,0,0] );
-        qOrient.premultiply( qAlign );
+        // const qOrient = quatFromAxis( [0,1,0], [0,0,1], [1,0,0] ).invert(); // FWD: +X, UP: +Z, RIGHT: +Y
+        // const qAlign  = quatFromAxis( [0,0,-1], [0,1,0], [1,0,0] );
+        // qOrient.premultiply( qAlign );
 
-        mesh.position.applyQuaternion( qOrient );
+        // mesh.position.applyQuaternion(qAlign);
 
         //------------------------------------------
         scene.add( mesh );
@@ -513,7 +525,7 @@ class CityRenderer {
     // move Up and Down without needing any changes its own transform that may be needed 
     // to conform to a different world orientation.
     mpos.y += 0.7;
-    mpos.x += -0.5; // Move it Left so So I can see the side of the cube to see the color of the left face
+    // mpos.x += -0.5; // Move it Left so So I can see the side of the cube to see the color of the left face
 
     //-----------------------
     this.cube.position.copy( mpos );
@@ -522,9 +534,17 @@ class CityRenderer {
   render(view, viewMatrix, projMatrix) {
     const { camera, scene, renderer, viewer } = this;
 
-    //this.camera.matrix.fromArray( viewMatrix ).invert();
-    this.camera.matrix.fromArray( reorientCamera( viewMatrix ) );
+    // this.camera.matrix.fromArray( viewMatrix ).invert();
+    // this.camera.matrix.fromArray( reorientCamera( viewMatrix ) );
 
+    const matrix = MJS_TRANSFORM
+        .clone()
+        .multiply( 
+            new THREE.Matrix4()
+                .fromArray(viewMatrix)
+                .invert());
+
+    this.camera.matrix.copy(matrix);
     this.camera.updateMatrixWorld(true);
     this.camera.projectionMatrix.fromArray(projMatrix);
 

--- a/web/viewer_with_2panes_rot_city.html
+++ b/web/viewer_with_2panes_rot_city.html
@@ -387,6 +387,9 @@ class MapView{
     // #endregion
 }
 
+const MJS_TRANSFORM = new THREE.Matrix4()
+        .makeRotationFromEuler(
+            new THREE.Euler(Math.PI / 2, 0, 0));
 
 // Render City in Mapillary
 class CityRenderer {
@@ -426,7 +429,7 @@ class CityRenderer {
             })
         );
 
-        mesh.rotation.set( Math.PI * 0.5, 0, 0 );
+        mesh.rotation.setFromRotationMatrix(MJS_TRANSFORM);
         mesh.geometry.computeBoundingBox();
         mesh.geometry.computeBoundingSphere();
         
@@ -502,7 +505,10 @@ class CityRenderer {
     // Note: Since the ViewMatrix changes the world's orientation, UP is now RIGHT. So
     // any movements on the Y axis moves things LEFT to RIGHT, not UP/DOWN as the
     // original intent of the 3D model was created for illustrating.
-    mpos.y -= 0.7;  
+
+    const translation = new THREE.Vector3(0, 0.7, 0);
+    translation.applyMatrix4(MJS_TRANSFORM);
+    mpos.add(translation);
     
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     this.cube.position.copy( mpos );
@@ -539,6 +545,7 @@ function facedCube( pos=null, scl=null ){
     ];
 
     const mesh = new THREE.Mesh( geo, mat );
+    mesh.rotation.setFromRotationMatrix(MJS_TRANSFORM);
     
     if( pos )			mesh.position.fromArray( pos );
     if( scl != null )	mesh.scale.set( scl, scl, scl );


### PR DESCRIPTION
This PR is just for visualizing another way applying transforms to achieve the correct model orientation.

It simplifies a bit the logic for:

1. Transforming the camera matrix + object position for the `Camera Rotation` case.
2. Transforming the object rotation + translation for the `City Rotation` case.

The behavior is now equivalent between the two example pages. The second case is the inverse of the first case. Instead of using a matrix, we could create a constant quaternion and apply in the same way.

Note that we do not need to call reorient camera and decompose the matrix in the `Camera Rotation` case.